### PR TITLE
Update asv.conf.json to point to main branch

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -39,7 +39,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["smg/cellfinder-cli-benchmark"], // for git
+    "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically


### PR DESCRIPTION
Previously it was pointing to  "smg/cellfinder-cli-benchmark", but this has now been merged and the branch deleted
