### PR TITLE
Remove Docker build

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -76,35 +76,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TWINE_API_KEY }}
-
-  build-and-push-docker:
-    needs: [upload_all]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM tensorflow/tensorflow:latest-gpu
-LABEL maintainer="code@adamltyson.com"
-RUN pip install brainglobe-workflows
-CMD ["bash"]


### PR DESCRIPTION
As per discussion on Zulip, the Docker image distribution for `cellfinder` will be discontinued.

`workflows` is designed with a streamlined install, so long as users have a `conda` environment, they should be able to install the `cellfinder` workflow without any issues in a lightweight manner anyway.