### PR TITLE
Rename incorrect instances of cellfinder to brainmapper

### DIFF
--- a/brainglobe_workflows/brainmapper/main.py
+++ b/brainglobe_workflows/brainmapper/main.py
@@ -2,7 +2,7 @@
 main
 ===============
 
-Runs each part of the cellfinder pipeline in turn.
+Runs each part of the brainmapper pipeline in turn.
 
 N.B imports are within functions to prevent tensorflow being imported before
 it's warnings are silenced
@@ -47,7 +47,7 @@ def main():
     from brainglobe_workflows.brainmapper.tools import prep
 
     start_time = datetime.now()
-    args, arg_groups, what_to_run, atlas = prep.prep_cellfinder_general()
+    args, arg_groups, what_to_run, atlas = prep.prep_brainmapper_general()
 
     if what_to_run.register:
         # TODO: add register_part_brain option

--- a/brainglobe_workflows/brainmapper/tools/parser.py
+++ b/brainglobe_workflows/brainmapper/tools/parser.py
@@ -54,7 +54,7 @@ def valid_model_depth(depth):
         )
 
 
-def cellfinder_parser():
+def brainmapper_parser():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser = main_parse(parser)
     parser = config_parse(parser)
@@ -161,7 +161,7 @@ def pixel_parser(parser):
 
 def run_parse(parser):
     run_parser = parser.add_argument_group(
-        "Options to disable part of cellfinder"
+        "Options to disable part of brainmapper"
     )
     run_parser.add_argument(
         "--no-detection",
@@ -432,7 +432,7 @@ def misc_parse(parser):
         type=check_positive_float,
         default=None,
         help="Maximum amount of RAM to use (in GB) - not currently fully "
-        "implemented for all parts of cellfinder",
+        "implemented for all parts of brainmapper",
     )
     misc_parser.add_argument(
         "--save-csv",

--- a/brainglobe_workflows/brainmapper/tools/prep.py
+++ b/brainglobe_workflows/brainmapper/tools/prep.py
@@ -21,7 +21,7 @@ import brainglobe_workflows as program_for_log
 import brainglobe_workflows.brainmapper.tools.parser as parser
 from brainglobe_workflows.brainmapper.tools import system, tools
 from brainglobe_workflows.brainmapper.tools.parser import (
-    cellfinder_parser,
+    brainmapper_parser,
 )
 
 
@@ -39,9 +39,9 @@ def get_arg_groups(args, parser):
 def check_input_arg_existance(args):
     """
     Does a simple check to ensure that input files/paths exist. Prevents a typo
-    from causing cellfinder to only run partway. Doesn't check for validity
-    etc, just existance.
-    :param args: Cellfinder input arguments
+    from causing brainmapper to only run partway. Doesn't check for validity
+    etc, just existence.
+    :param args: brainmapper input arguments
     """
     check_list = [args.background_planes_path[0]]
     check_list = check_list + args.signal_planes_paths
@@ -53,7 +53,7 @@ def check_input_arg_existance(args):
 
 class Paths:
     """
-    A single class to hold all file paths that cellfinder may need. Any paths
+    A single class to hold all file paths that brainmapper may need. Any paths
     prefixed with "tmp__" refer to internal intermediate steps, and will be
     deleted if "--debug" is not used.
     """
@@ -63,7 +63,7 @@ class Paths:
         self.registration_output_folder = os.path.join(
             self.output_dir, "registration"
         )
-        self.metadata_path = os.path.join(self.output_dir, "cellfinder.json")
+        self.metadata_path = os.path.join(self.output_dir, "brainmapper.json")
         self.registration_metadata_path = os.path.join(
             self.registration_output_folder, "brainreg.json"
         )
@@ -107,9 +107,9 @@ def log_metadata(file_path, args):
         json.dump(args, f, default=serialise)
 
 
-def prep_cellfinder_general():
-    args = parser.cellfinder_parser().parse_args()
-    arg_groups = get_arg_groups(args, cellfinder_parser())
+def prep_brainmapper_general():
+    args = parser.brainmapper_parser().parse_args()
+    arg_groups = get_arg_groups(args, brainmapper_parser())
 
     check_input_arg_existance(args)
 
@@ -123,7 +123,7 @@ def prep_cellfinder_general():
         program_for_log,
         variables=[args, args.paths],
         verbose=args.debug,
-        log_header="CELLFINDER LOG",
+        log_header="BRAINMAPPER LOG",
         multiprocessing_aware=True,
     )
 
@@ -153,7 +153,7 @@ def check_and_return_ch_ids(signal_ids, background_id, signal_channel_list):
     """
 
     # TODO: make this more general, so it gives informative error messages
-    #  when called from cellfinder.extract.cli
+    #  when called from brainmapper.extract.cli
 
     num_signal_channels = len(signal_channel_list)
 


### PR DESCRIPTION
Before release, this will need `brainglobe-napari-io` to be updated to detect the renamed `brainmapper.json`.

Closes #63 

As it turns out the log file is named automatically, so this just changes the metadata file. 