### PR TITLE
Add hard dependency on brainglobe-meta package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "brainglobe>=1.0.0",
     "brainreg>=1.0.0",
-    "cellfinder>=1.0.0",
+    "cellfinder>=1.1.0",
     "configobj",
     "fancylog>=0.0.7",
     "imio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 # Below the dependenciess for the cellfinder CLI tool only
 # (i.e., only what users will need for the CLI)
 dependencies = [
+    "brainglobe>=1.0.0",
     "brainreg>=1.0.0",
     "cellfinder>=1.0.0",
     "configobj",


### PR DESCRIPTION
See https://github.com/brainglobe/BrainGlobe/issues/33 | This should be the final task in the list, so it actually closes https://github.com/brainglobe/BrainGlobe/issues/33 :scream: 

As per the version 1 release plan, this repository should depend on the meta-package rather than the individual tooling packages themselves.

As such, have added `brainglobe>=1.0.0` to the top of the dependency list.
Have left in the explicit `brainreg>=1.0.0` and `cellfinder>=1.0.0` dependencies, even though these (or the most recent versions) should be fetched by the meta-package anyway.
This just ensures that the minimum version of the meta-package that will be fetched must be one that adheres to our BrainGlobe version 1 update: IE fetching the new cellfinder package and brainreg plugins.

Depends on:
- https://github.com/brainglobe/brainglobe.github.io/pull/132
- https://github.com/brainglobe/brainglobe-meta/pull/38
- New release to PyPI of `brainglobe-meta` version 1.

CI will fail until all of the above are met.