### PR TITLE
update to new cellfinder function names

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,8 +26,17 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/check_manifest@v2
 
-  test:
+
+  tmate:
     needs: [linting, manifest]
+    name: Run tmate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up tmate
+        uses: mxschmitt/action-tmate@v3
+
+  test:
+    needs: [linting, manifest, tmate]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/brainglobe_workflows/brainmapper/parser.py
+++ b/brainglobe_workflows/brainmapper/parser.py
@@ -22,7 +22,7 @@ from cellfinder.core.download.cli import (
     download_directory_parser,
     model_parser,
 )
-from cellfinder.core.tools.source_files import source_custom_config_cellfinder
+from cellfinder.core.tools.source_files import user_specific_configuration_path
 
 from brainglobe_workflows import __version__
 
@@ -388,7 +388,7 @@ def config_parse(parser):
         "--config",
         dest="registration_config",
         type=str,
-        default=source_custom_config_cellfinder(),
+        default=user_specific_configuration_path(),
         help="To supply your own, custom configuration file.",
     )
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We've updated some function names as part of https://github.com/brainglobe/cellfinder/pull/394

**What does this PR do?**
Updates the function names.

When this is merged, I think we should
- [x] release cellfinder 1.1.2
- [ ] release brainglobe 1.0.5, which should depend on cellfinder >= 1.1.2
- [ ] release brainglobe-workflows 1.1.5 depending on brainglobe >=1.0.5

## References

https://github.com/brainglobe/cellfinder/pull/394 and https://github.com/brainglobe/cellfinder/issues/393

## How has this PR been tested?

Locally, which current main of `cellfinder` installed.

## Is this a breaking change?

Yes, this will now require cellfinder >=1.1.2

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
