### PR TITLE
Support single z-stack tif file for input

### DIFF
--- a/brainglobe_workflows/brainmapper/main.py
+++ b/brainglobe_workflows/brainmapper/main.py
@@ -105,7 +105,7 @@ def run_all(args, what_to_run, atlas):
     from cellfinder.core.classify import classify
     from cellfinder.core.detect import detect
     from cellfinder.core.tools import prep
-    from cellfinder.core.tools.IO import read_with_dask
+    from cellfinder.core.tools.IO import read_z_stack
 
     from brainglobe_workflows.brainmapper import analyse
     from brainglobe_workflows.brainmapper.prep import (
@@ -120,7 +120,7 @@ def run_all(args, what_to_run, atlas):
     if what_to_run.detect:
         logging.info("Detecting cell candidates")
         args = prep_candidate_detection(args)
-        signal_array = read_with_dask(
+        signal_array = read_z_stack(
             args.signal_planes_paths[args.signal_channel]
         )
 
@@ -165,11 +165,11 @@ def run_all(args, what_to_run, atlas):
             if points is None:
                 points = get_cells(args.paths.detected_points)
             if signal_array is None:
-                signal_array = read_with_dask(
+                signal_array = read_z_stack(
                     args.signal_planes_paths[args.signal_channel]
                 )
             logging.info("Running cell classification")
-            background_array = read_with_dask(args.background_planes_path[0])
+            background_array = read_z_stack(args.background_planes_path[0])
 
             points = classify.main(
                 points,

--- a/brainglobe_workflows/cellfinder_core/cellfinder_core.py
+++ b/brainglobe_workflows/cellfinder_core/cellfinder_core.py
@@ -30,7 +30,7 @@ from typing import Optional, Union
 import pooch
 from brainglobe_utils.IO.cells import save_cells
 from cellfinder.core.main import main as cellfinder_run
-from cellfinder.core.tools.IO import read_with_dask
+from cellfinder.core.tools.IO import read_z_stack
 from cellfinder.core.train.train_yml import depth_type
 
 from brainglobe_workflows.utils import (
@@ -356,7 +356,7 @@ def run_workflow_from_cellfinder_run(cfg: CellfinderConfig):
 
     The steps are:
     1. Read the input signal and background data as two separate
-       Dask arrays.
+       Dask (or memory if single file stack) arrays.
     2. Run the main cellfinder pipeline on the input Dask arrays,
        with the parameters defined in the input configuration (cfg).
     3. Save the detected cells as an xml file to the location specified in
@@ -369,8 +369,8 @@ def run_workflow_from_cellfinder_run(cfg: CellfinderConfig):
         the cellfinder workflow
     """
     # Read input data as Dask arrays
-    signal_array = read_with_dask(str(cfg._signal_dir_path))
-    background_array = read_with_dask(str(cfg._background_dir_path))
+    signal_array = read_z_stack(str(cfg._signal_dir_path))
+    background_array = read_z_stack(str(cfg._background_dir_path))
 
     # Run main analysis using `cellfinder_run`
     detected_cells = cellfinder_run(


### PR DESCRIPTION
This is part of this PR: https://github.com/brainglobe/cellfinder/pull/397.

I had to fix this manually for the tests to pass. But this is an issue with the repo, not these changes:

```
ImportError while importing test module 'D:\code\cellcount\brainglobe-workflows\tests\brainmapper\test_unit\test_prep.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Prog\Python\Python310\lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests\brainmapper\test_unit\test_prep.py:6: in <module>
    from brainglobe_workflows.brainmapper import prep
brainglobe_workflows\brainmapper\prep.py:25: in <module>
    import brainglobe_workflows.brainmapper.parser as parser
brainglobe_workflows\brainmapper\parser.py:25: in <module>
    from cellfinder.core.tools.source_files import source_custom_config_cellfinder
E   ImportError: cannot import name 'source_custom_config_cellfinder' from 'cellfinder.core.tools.source_files' (D:\code\cellcount\cellfinder\cellfinder\core\tools\source_files.py)
```

Then is succeded except of these tests, which I don't think are related to this PR

```
========================================================================================================== short test summary info =========================================================================================================== FAILED tests/brainmapper/test_integration/test_detection.py::test_detection_full - OSError: Unable to synchronously open file (truncated file: eof = 66060288, sblock->base_addr = 0, stored_eof = 184831728)
FAILED tests/cellfinder_core/test_integration/test_cellfinder.py::test_main - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
FAILED tests/cellfinder_core/test_integration/test_cellfinder.py::test_main_w_inputs[config_local_json] - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
FAILED tests/cellfinder_core/test_integration/test_cellfinder.py::test_main_w_inputs[config_GIN_json] - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
FAILED tests/cellfinder_core/test_integration/test_cellfinder.py::test_entry_point_help - FileNotFoundError: [WinError 2] The system cannot find the file specified
FAILED tests/cellfinder_core/test_unit/test_cellfinder.py::test_run_workflow_from_cellfinder_run[default_input_config_cellfinder] - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
FAILED tests/cellfinder_core/test_unit/test_cellfinder.py::test_run_workflow_from_cellfinder_run[config_local_json] - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
FAILED tests/cellfinder_core/test_unit/test_cellfinder.py::test_run_workflow_from_cellfinder_run[config_GIN_json] - FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Matthew Einhorn\\.brainglobe-tests\\.cellfinder\\cellfinder.conf.custom'
================================================================================ 8 failed, 14 passed, 1 skipped, 1 xfailed, 39 warnings in 407.22s (0:06:47) =================================================================================
```