### PR TITLE
Replace source_custom_config_cellfinder with newer function

### DIFF
--- a/brainglobe_workflows/brainmapper/parser.py
+++ b/brainglobe_workflows/brainmapper/parser.py
@@ -22,7 +22,7 @@ from cellfinder.core.download.cli import (
     download_directory_parser,
     model_parser,
 )
-from cellfinder.core.tools.source_files import source_custom_config_cellfinder
+from cellfinder.core.tools.source_files import user_specific_configuration_path
 
 from brainglobe_workflows import __version__
 
@@ -388,7 +388,7 @@ def config_parse(parser):
         "--config",
         dest="registration_config",
         type=str,
-        default=source_custom_config_cellfinder(),
+        default=user_specific_configuration_path(),
         help="To supply your own, custom configuration file.",
     )
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`source_custom_config_cellfinder` was changed to `user_specific_configuration_path` in https://github.com/brainglobe/cellfinder/pull/394, so we need to update the usage her as well.

**What does this PR do?**

Updates the usage.

## References

[Please reference any existing issues/PRs that relate to this PR.](https://github.com/brainglobe/cellfinder/pull/394)

## How has this PR been tested?

Made the changes locally so that tests worked.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
