### PR TITLE
Remove entry point for cellfinder workflow

### DIFF
--- a/brainglobe_workflows/cellfinder_core/cellfinder_core.py
+++ b/brainglobe_workflows/cellfinder_core/cellfinder_core.py
@@ -438,7 +438,6 @@ def main(
 
 
 if __name__ == "__main__":
-
     # parse CLI arguments
     args = config_parser(
         sys.argv[1:],

--- a/brainglobe_workflows/cellfinder_core/cellfinder_core.py
+++ b/brainglobe_workflows/cellfinder_core/cellfinder_core.py
@@ -437,27 +437,13 @@ def main(
     return cfg
 
 
-def main_app_wrapper():
-    """Parse command line arguments and
-    run cellfinder setup and workflow
+if __name__ == "__main__":
 
-    This function is used to define an entry-point,
-    that allows the user to run the cellfinder workflow
-    for a given input config file as:
-    `cellfinder-workflow --config <path-to-input-config>`.
-
-    If no input config file is provided, the default is used.
-
-    """
     # parse CLI arguments
     args = config_parser(
-        sys.argv[1:],  # sys.argv[0] is the script name
+        sys.argv[1:],
         str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER),
     )
 
     # run setup and workflow
     _ = main(args.config)
-
-
-if __name__ == "__main__":
-    main_app_wrapper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ napari = ["napari[pyqt5]", "brainglobe-napari-io", "cellfinder[napari]>=1.0.0"]
 "Source Code" = "https://github.com/brainglobe/brainglobe-workflows"
 
 [project.scripts]
-cellfinder-workflow = "brainglobe_workflows.cellfinder_core.cellfinder_core:main_app_wrapper"
 brainmapper = "brainglobe_workflows.brainmapper.main:main"
 
 [build-system]

--- a/tests/cellfinder_core/test_integration/test_cellfinder.py
+++ b/tests/cellfinder_core/test_integration/test_cellfinder.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 from typing import Optional
 

--- a/tests/cellfinder_core/test_integration/test_cellfinder.py
+++ b/tests/cellfinder_core/test_integration/test_cellfinder.py
@@ -50,21 +50,3 @@ def test_main_w_inputs(
 
     # check output files exist
     assert Path(cfg._detected_cells_path).is_file()
-
-
-def test_entry_point_help():
-    """
-    Smoke test the cellfinder workflow entry point by checking
-    help is printed out successfully
-    """
-
-    # define CLI input
-    subprocess_input = ["cellfinder-workflow", "--help"]
-
-    # run workflow
-    subprocess_output = subprocess.run(
-        subprocess_input,
-    )
-
-    # check returncode
-    assert subprocess_output.returncode == 0


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We expect that the main way the workflows will be useful for users is as reference scripts that they can "copy-paste" and adapt to their workflows. Therefore for simplicity we agreed to remove the entry point for the cellfinder workflow script.

Related to #9 

**What does this PR do?**
Removes the entry point to the cellfinder workflow script

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

We had smoke tests for the entry point before but these are removed in this PR.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
