### PR TITLE
Run cellfinder benchmarks on small data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,3 +24,4 @@ prune resources
 
 prune .github
 prune .tox
+prune .asv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,11 +10,12 @@ exclude *.ini
 recursive-include brainglobe_workflows *.py
 recursive-include brainglobe_workflows/configs *.json
 recursive-include benchmarks *.py
-recursive-exclude benchmarks/results *
 include asv.conf.json
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude benchmarks/results *
+recursive-exclude benchmarks/html *
 
 global-include *.pxd
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,18 @@ See our [blog post](https://brainglobe.info/blog/version1/cellfinder-core-and-pl
 
 ## Developer documentation
 
-This repository also includes workflow scripts that are benchmarked to support code development.
-These benchmarks are run regularly to ensure performance is stable, as the tools are developed and extended.
+This repository also includes code to benchmark typical workflows.
+These benchmarks are meant to be run regularly, to ensure performance is stable as the tools are developed and extended.
 
-- Developers can install these benchmarks locally via `pip install .[dev]`. By executing `asv run`, the benchmarks will run with default parameters on a small dataset that is downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki). See [the asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further details on how to run benchmarks.
-- Developers can also run these benchmarks on data they have stored locally, by specifying the relevant paths in an input (JSON) file.
-- We also maintain an internal runner that benchmarks the workflows over a large, exemplar dataset, of the scale we expect users to be handling. The result of these benchmarks are made publicly available.
+There are three main ways in which these benchmarks can be useful to developers:
+1. Developers can run the available benchmarks locally on a small test dataset.
+    To do so:
+    - Install the developer version of the package with `pip install .[dev]`.
+    - Run `asv run`. This will run the benchmarks with default parameters on a small dataset downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki).
+    - See [the asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further guidance on how to run benchmarks.
+1. Developers can also run these benchmarks on data they have stored locally.
+    - To do so, add an "input_data_dir" field in the default config pointing to the data of interest. The signal and background data are expected to be in "signal" and "background" subdirectories under "input_data_dir".
+1. We also plan to run the benchmarks on an internal runner using a larger dataset, of the scale we expect users to be handling. The result of these benchmarks will be made publicly available.
 
 Contributions to BrainGlobe are more than welcome.
 Please see the [developer guide](https://brainglobe.info/developers/index.html).

--- a/README.md
+++ b/README.md
@@ -73,21 +73,29 @@ These benchmarks are meant to be run regularly, to ensure performance is stable 
 
 There are three main ways in which these benchmarks can be useful to developers:
 1. Developers can run the available benchmarks locally on a small test dataset.
+
     To do so:
     - Install the developer version of the package:
         ```
         pip install .[dev]
         ```
-        This is mostly for convenience: the `[dev]` specification includes `asv` as a dependency, but to run the benchmarks it would be sufficient to use an environment with `asv` only. This is because `asv` creates its own virtual environment for the benchmarks, building and installing the requested version of the package in it.
+        This is mostly for convenience: the `[dev]` specification includes `asv` as a dependency, but to run the benchmarks it would be sufficient to use an environment with `asv` only. This is because `asv` creates its own virtual environment for the benchmarks, building and installing the relevant version of the `brainglobe-workflows` package in it. By default, the version at the tip of main is installed.
     - Run the benchmarks:
         ```
         asv run
         ```
-       This will run the locally defined benchmarks with the default parameters defined at `brainglobe_workflows/configs/cellfinder.json`, on a small dataset downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki). See [the asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further guidance on how to run benchmarks.
+       This will run the locally defined benchmarks with the default parameters defined at `brainglobe_workflows/configs/cellfinder.json`, on a small dataset downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki). See the [asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further guidance on how to run benchmarks.
 1. Developers can also run these benchmarks on data they have stored locally.
+
     To do so:
-    - Add an `input_data_dir` field in the default config at `brainglobe_workflows/configs/cellfinder.json` pointing to the data of interest.
-    - Edit the names of the signal and background directories if required.By default, they are assumed to be in `signal` and `background` subdirectories under `input_data_dir`. However, these defaults can be overwritten with the `signal_subdir` and `background_subdir` fields.
+    - Define a config file for the workflow to benchmark. You can use the default one at `brainglobe_workflows/configs/cellfinder.json` for reference.
+    - Ensure your config file includes an `input_data_dir` field pointing to the data of interest.
+    - Edit the names of the signal and background directories if required. By default, they are assumed to be in `signal` and `background` subdirectories under `input_data_dir`. However, these defaults can be overwritten with the `signal_subdir` and `background_subdir` fields.
+    - Run the benchmarks, passing the path to your config file as an environment variable `CONFIG_PATH`. In Unix systems:
+        ```
+        CONFIG_PATH=/path/to/your/config/file asv run
+        ```
+
 1. We also plan to run the benchmarks on an internal runner using a larger dataset, of the scale we expect users to be handling. The result of these benchmarks will be made publicly available.
 
 Contributions to BrainGlobe are more than welcome.

--- a/README.md
+++ b/README.md
@@ -74,11 +74,20 @@ These benchmarks are meant to be run regularly, to ensure performance is stable 
 There are three main ways in which these benchmarks can be useful to developers:
 1. Developers can run the available benchmarks locally on a small test dataset.
     To do so:
-    - Install the developer version of the package with `pip install .[dev]`.
-    - Run `asv run`. This will run the benchmarks with default parameters on a small dataset downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki).
-    - See [the asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further guidance on how to run benchmarks.
+    - Install the developer version of the package:
+        ```
+        pip install .[dev]
+        ```
+        This is mostly for convenience: the `[dev]` specification includes `asv` as a dependency, but to run the benchmarks it would be sufficient to use an environment with `asv` only. This is because `asv` creates its own virtual environment for the benchmarks, building and installing the requested version of the package in it.
+    - Run the benchmarks:
+        ```
+        asv run
+        ```
+       This will run the locally defined benchmarks with the default parameters defined at `brainglobe_workflows/configs/cellfinder.json`, on a small dataset downloaded from [GIN](https://gin.g-node.org/G-Node/info/wiki). See [the asv docs](https://asv.readthedocs.io/en/v0.6.1/using.html#running-benchmarks) for further guidance on how to run benchmarks.
 1. Developers can also run these benchmarks on data they have stored locally.
-    - To do so, add an "input_data_dir" field in the default config pointing to the data of interest. The signal and background data are expected to be in "signal" and "background" subdirectories under "input_data_dir".
+    To do so:
+    - Add an `input_data_dir` field in the default config at `brainglobe_workflows/configs/cellfinder.json` pointing to the data of interest.
+    - Edit the names of the signal and background directories if required.By default, they are assumed to be in `signal` and `background` subdirectories under `input_data_dir`. However, these defaults can be overwritten with the `signal_subdir` and `background_subdir` fields.
 1. We also plan to run the benchmarks on an internal runner using a larger dataset, of the scale we expect users to be handling. The result of these benchmarks will be made publicly available.
 
 Contributions to BrainGlobe are more than welcome.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are three main ways in which these benchmarks can be useful to developers:
         ```
         pip install .[dev]
         ```
-        This is mostly for convenience: the `[dev]` specification includes `asv` as a dependency, but to run the benchmarks it would be sufficient to use an environment with `asv` only. This is because `asv` creates its own virtual environment for the benchmarks, building and installing the relevant version of the `brainglobe-workflows` package in it. By default, the version at the tip of main is installed.
+        This is mostly for convenience: the `[dev]` specification includes `asv` as a dependency, but to run the benchmarks it would be sufficient to use an environment with `asv` only. This is because `asv` creates its own virtual environment for the benchmarks, building and installing the relevant version of the `brainglobe-workflows` package in it. By default, the version at the tip of the currently checked out branch is installed.
     - Run the benchmarks:
         ```
         asv run

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "brainglobe_workflows",
+    "project": "brainglobe-workflows",
 
     // The project's homepage
     "project_url": "https://github.com/brainglobe/brainglobe-workflows",
@@ -12,7 +12,7 @@
     // The URL or local path of the source code repository for the
     // project being benchmarked
     // "repo": ".",
-    "repo": "https://github.com/brainglobe/brainglobe-workflows",
+    "repo": "https://github.com/brainglobe/brainglobe-workflows.git",
 
     // The Python project's subdirectory in your repo.  If missing or
     // the empty string, the project is assumed to be located at the root
@@ -40,14 +40,14 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["smg/tests-refactor"], // for git
+    "branches": ["main"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as
     // ".git" (if local).
-    "dvcs": "git",
+    // "dvcs": "git",
 
     // The tool to use to create environments.  May be "conda",
     // "virtualenv", "mamba" (above 3.8)
@@ -147,7 +147,7 @@
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
-    "benchmark_dir": "brainglobe_benchmarks",
+    "benchmark_dir": "benchmarks",
 
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
@@ -155,11 +155,11 @@
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
-    "results_dir": "brainglobe_benchmarks/results",
+    "results_dir": "benchmarks/results",
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
-    "html_dir": "brainglobe_benchmarks/html",
+    "html_dir": "benchmarks/html",
 
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "brainglobe-workflows",
+    "project": "../brainglobe-workflows",
 
     // The project's homepage
     "project_url": "https://github.com/brainglobe/brainglobe-workflows",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -11,8 +11,8 @@
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
-    // "repo": ".",
-    "repo": "https://github.com/brainglobe/brainglobe-workflows.git",
+    "repo": ".",
+    // "repo": "https://github.com/brainglobe/brainglobe-workflows.git",
 
     // The Python project's subdirectory in your repo.  If missing or
     // the empty string, the project is assumed to be located at the root
@@ -40,7 +40,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["main"], // for git
+    "branches": ["HEAD"], // for git
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically

--- a/benchmarks/cellfinder_core.py
+++ b/benchmarks/cellfinder_core.py
@@ -17,7 +17,7 @@ from brainglobe_workflows.cellfinder_core.cellfinder_core import (
 from brainglobe_workflows.utils import DEFAULT_JSON_CONFIG_PATH_CELLFINDER
 
 
-class TimeBenchmarkPrepGIN:
+class TimeBenchmark:
     """
 
     A base class for timing benchmarks for the cellfinder workflow.
@@ -142,7 +142,7 @@ class TimeBenchmarkPrepGIN:
         shutil.rmtree(Path(self.cfg._output_path).resolve())
 
 
-class TimeFullWorkflow(TimeBenchmarkPrepGIN):
+class TimeFullWorkflow(TimeBenchmark):
     """
     Time the full cellfinder workflow.
 
@@ -151,7 +151,7 @@ class TimeFullWorkflow(TimeBenchmarkPrepGIN):
 
     Parameters
     ----------
-    TimeBenchmarkPrepGIN : _type_
+    TimeBenchmark : _type_
         A base class for timing benchmarks for the cellfinder workflow.
     """
 
@@ -159,13 +159,13 @@ class TimeFullWorkflow(TimeBenchmarkPrepGIN):
         run_workflow_from_cellfinder_run(self.cfg)
 
 
-class TimeReadInputDask(TimeBenchmarkPrepGIN):
+class TimeReadInputDask(TimeBenchmark):
     """
     Time the reading input data operations with dask
 
     Parameters
     ----------
-    TimeBenchmarkPrepGIN : _type_
+    TimeBenchmark : _type_
         A base class for timing benchmarks for the cellfinder workflow.
     """
 
@@ -176,20 +176,20 @@ class TimeReadInputDask(TimeBenchmarkPrepGIN):
         read_with_dask(str(self.cfg._background_dir_path))
 
 
-class TimeDetectCells(TimeBenchmarkPrepGIN):
+class TimeDetectAndClassifyCells(TimeBenchmark):
     """
     Time the cell detection main pipeline (`cellfinder_run`)
 
     Parameters
     ----------
-    TimeBenchmarkPrepGIN : _type_
+    TimeBenchmark : _type_
         A base class for timing benchmarks for the cellfinder workflow.
     """
 
     # extend basic setup function
     def setup(self):
         # basic setup
-        TimeBenchmarkPrepGIN.setup(self)
+        TimeBenchmark.setup(self)
 
         # add input data as arrays to the config
         self.signal_array = read_with_dask(str(self.cfg._signal_dir_path))
@@ -225,11 +225,11 @@ class TimeDetectCells(TimeBenchmarkPrepGIN):
         )
 
 
-class TimeSaveCells(TimeBenchmarkPrepGIN):
+class TimeSaveCells(TimeBenchmark):
     # extend basic setup function
     def setup(self):
         # basic setup
-        TimeBenchmarkPrepGIN.setup(self)
+        TimeBenchmark.setup(self)
 
         # add input data as arrays to config
         self.signal_array = read_with_dask(str(self.cfg._signal_dir_path))

--- a/benchmarks/cellfinder_core.py
+++ b/benchmarks/cellfinder_core.py
@@ -82,7 +82,7 @@ class TimeBenchmark:
     # Input config file
     # use environment variable CONFIG_PATH if exists, otherwise use default
     input_config_path = os.getenv(
-        "CONFIG_PATH", default=str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER)
+        "CELLFINDER_CONFIG_PATH", default=str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER)
     )
 
     def setup_cache(self):

--- a/benchmarks/cellfinder_core.py
+++ b/benchmarks/cellfinder_core.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 from pathlib import Path
 
@@ -78,8 +79,11 @@ class TimeBenchmark:
     sample_time = 0.01  # default: 10 ms = 0.01 s;
     min_run_count = 2  # default:2
 
-    # Custom attributes
-    input_config_path = str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER)
+    # Input config file
+    # use environment variable CONFIG_PATH if exists, otherwise use default
+    input_config_path = os.getenv(
+        "CONFIG_PATH", default=str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER)
+    )
 
     def setup_cache(self):
         """

--- a/benchmarks/cellfinder_core.py
+++ b/benchmarks/cellfinder_core.py
@@ -82,7 +82,8 @@ class TimeBenchmark:
     # Input config file
     # use environment variable CONFIG_PATH if exists, otherwise use default
     input_config_path = os.getenv(
-        "CELLFINDER_CONFIG_PATH", default=str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER)
+        "CELLFINDER_CONFIG_PATH",
+        default=str(DEFAULT_JSON_CONFIG_PATH_CELLFINDER),
     )
 
     def setup_cache(self):

--- a/benchmarks/cellfinder_core.py
+++ b/benchmarks/cellfinder_core.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from brainglobe_utils.IO.cells import save_cells
 from cellfinder.core.main import main as cellfinder_run
 from cellfinder.core.tools.IO import read_with_dask
+from cellfinder.core.tools.prep import prep_models
 
 from brainglobe_workflows.cellfinder_core.cellfinder_core import (
     CellfinderConfig,
@@ -102,14 +103,21 @@ class TimeBenchmarkPrepGIN:
         assert Path(self.input_config_path).exists()
 
         # Instantiate a CellfinderConfig from the input json file
-        # (assumes config is json serializable)
+        # (fetches data from GIN if required)
         with open(self.input_config_path) as cfg:
             config_dict = json.load(cfg)
         config = CellfinderConfig(**config_dict)
 
-        # Check paths to input data should now exist in config
+        # Check paths to input data exist in config now
         assert Path(config._signal_dir_path).exists()
         assert Path(config._background_dir_path).exists()
+
+        # Ensure cellfinder model is downloaded to default path
+        _ = prep_models(
+            model_weights_path=config.model_weights,
+            install_path=None,  # Use default,
+            model_name=config.model,
+        )
 
     def setup(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,12 @@ dev = [
     "pre-commit",
     "setuptools_scm",
     "asv",
-    "pooch",
 ]
 # Below, all the dependencies asv needs to run the benchmarks
 # (i.e., everything needed to install this package without the CLI tool)
 # Once the cellfinder CLI tool is deprecated, these will move to the
 # default dependencies.
-asv_version = ["asv", "pooch"]
+asv_version = ["asv"]
 
 napari = ["napari[pyqt5]", "brainglobe-napari-io", "cellfinder[napari]>=1.0.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 # (i.e., everything needed to install this package without the CLI tool)
 # Once the cellfinder CLI tool is deprecated, these will move to the
 # default dependencies.
-asv_version = ["asv", "pooch", "cellfinder-core"]
+asv_version = ["asv", "pooch"]
 
 napari = ["napari[pyqt5]", "brainglobe-napari-io", "cellfinder[napari]>=1.0.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,11 +86,7 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 include = ["brainglobe_workflows"]
-exclude = [
-    "tests",
-    "resources",
-    "benchmarks",
-]
+exclude = ["tests", "resources", "benchmarks"]
 
 [tool.black]
 target-version = ["py39", "py310"]
@@ -112,6 +108,11 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "serial",
 ]
+
+[tool.coverage.run]
+source = ["./*"]
+omit = ["benchmarks/*"]
+
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]
@@ -136,6 +137,10 @@ python =
 # is set to "true"
 INPUT_COREDEV =
     true: coredev
+
+[coverage:run]
+source = ./*
+omit = benchmarks/*
 
 [testenv]
 extras =


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We are exploring a systematic way to benchmark `brainglobe` workflows using [`asv`](https://asv.readthedocs.io/en/v0.6.1/). 

This PR fixes some issues running the  `cellfinder` workflow benchmarks (1) on a small GIN dataset and (2) on data available locally. 

**What does this PR do?**
This PR involves:
- edits on the asv config file (mainly to install in the asv environment the brainglobe-workflows package from the local repo),
- an update to the `setup_cache` function of the benchmarks,
- an option to run the benchmarks on locally available data using an environment variable, and
- edits to the readme file to reflect these updates.

### To run the benchmarks locally on small dataset from GIN
1. Checkout this branch to get the latest version of the benchmarks locally.

1. Create a conda environment and pip install `asv`:
	```
	conda create -n asv-check python=3.10
	conda activate asv-check
	pip install asv
	```
	Note that to run the benchmarks you do not need to install a development version of `brainglobe-workflows`, since `asv` will create a separate Python virtual environment to run the benchmarks on it. However, for convenience we do include `asv` as part of the `dev` dependencies, so you can use a `dev` environment to run benchmarks.
1. For a quick check, run one iteration per benchmark with 
    ```
    asv run -q
    ``` 
	- You can add `-v --show-stderr` for a more verbose output.
    - This will install in the `asv` virtual environment the `brainglobe-workflows` package from *the tip of the local currently checked out branch*, and run the (locally defined) benchmarks on it.

### To run the benchmarks (locally) on a locally available dataset
1. Define a config file for the workflow to benchmark. You can use the default one at `brainglobe_workflows/configs/cellfinder.json` for reference.
	 - Ensure your config file includes an `input_data_dir` field pointing to the data of interest.
	 - Edit the names of the signal and background directories if required. By default, they are assumed to be in `signal` and `background` subdirectories under `input_data_dir`. However, these defaults can be overwritten with the `signal_subdir` and `background_subdir` fields.
	 
1. Create and activate an environment with `asv` (follow steps 1 and 2 from above).

1. Run the benchmarks in "quick mode", passing the path to your config file as an environment variable `CONFIG_PATH`. In Unix systems:
    ```
    CONFIG_PATH=/path/to/your/config/file asv run -q
    ```

### Troubleshooting
You may find that the conda environment creation is failing because of [this issue](https://github.com/airspeed-velocity/asv/issues/1396). This seems to be because `asv` is assuming a conda syntax that changed with the latest release (in conda 24.3.0 `--force` became `--yes`). 

A [PR](https://github.com/airspeed-velocity/asv/pull/1397) is on the way, as a temporary workaround you can try from base `conda install -y "conda<24.3"`.

## References

See issue #9.

Also related is issue #98 which I am currently investigating.

### Further context
We currently have `asv` benchmarks for the three main steps involved in the `cellfinder` workflow:
 - reading input data, 
 - detecting and classifying cells, and 
 - saving the results to file.
 
We also have a benchmark for the full workflow.

We envisioned benchmarks being useful to developers in 3 main ways:
- Developers can run the available benchmarks locally on a small test dataset fetched from GIN. For this, the cellfinder workflow is run with the default config that ships with the package (at `brainglobe_workflows/configs/cellfinder.json`).
- Developers can also run these benchmarks on data they have stored locally. For this, the workflow is run with a custom config, whose path is passed to the benchmarks as an environment variable.
- We also plan to run the benchmarks on an internal runner using a larger dataset, of the scale we expect users to be handling. The result of these benchmarks will be made publicly available. This is not yet implemented.
This is all explained in the README.

A reminder of how `asv` works:
- `asv` creates a virtual environment where it installs the package to be benchmarked (in our case, `brainglobe-workflows`). This virtual environment is defined in the asv config file (`asv.conf.json`). 
- We set `asv` so that the version of `brainglobe-workflows` that is installed in the asv-managed virtual environment is the one at the tip of the currently checked out branch (i.e., the version at `HEAD`). This way developers can check if their local branch introduces regressions. Alternatively, we can choose to install a version of `brainglobe-workflows` fetched from Github (for example, the tip of the remote `main` branch).
- `asv` will look for benchmarks under the `benchmarks` folder (which is at the same level as the `asv.conf.json` file), and run them.


## How has this PR been tested?

The benchmarks are checked with a CI job, rather than with explicit tests. This follows the general approach in the field - see #96 for more details.

Since we don't plan to test the benchmarks with pytest, I omitted the benchmarks from coverage.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The README has been updated to better reflect the current status.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration) -- this is covered in PR #96
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
