### PR TITLE
Cache cellfinder model in CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,6 +43,14 @@ jobs:
         - os: windows-latest
           python-version: "3.10"
     steps:
+      # Cache the tensorflow model so we don't have to remake it every time
+      - name: Cache tensorflow model
+        uses: actions/cache@v3
+        with:
+          path: "~/.cellfinder"
+          key: models-${{ hashFiles('~/.cellfinder/**') }}
+
+      # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We are inspecting why CI is slow (work in progress) and this seemed a low hanging fruit which may improve a bit our timings.

**What does this PR do?**
It adds a step in the CI workflow for tests, for caching the cellfinder model. This is implemented in [`cellfinder` CI](https://github.com/brainglobe/cellfinder/blob/e6a887f1721b89d51328214b108e0da5401a24a9/.github/workflows/test_and_deploy.yml#L53C7-L58C59) but not here.

## References

Related to #65. 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
