### PR TITLE
naive attempt at fixing HDF5

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,11 +52,10 @@ jobs:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
       # install additional Macos dependencies
-      - name: install HDF5 libraries
+      - name: install HDF5 libraries (needed on M1 Macs only)
         if: matrix.os == 'macos-latest'
         run: |
           brew install hdf5
-          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -51,12 +51,6 @@ jobs:
         with:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
-      # install additional Macos dependencies
-      - name: install HDF5 libraries
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install hdf5
-          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,12 +36,14 @@ jobs:
         # Run tests on ubuntu across all supported versions
         python-version: ["3.9", "3.10"]
         os: [ubuntu-latest]
-        # Include at least one MacOS and Windows test
+        # Include a Windows test and old/new Mac runs
         include:
-        - os: macos-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.10"
+          - os: macos-13
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
     steps:
       # Cache the tensorflow model so we don't have to remake it every time
       - name: Cache tensorflow model
@@ -49,7 +51,12 @@ jobs:
         with:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
-
+      # install additional Macos dependencies
+      - name: install HDF5 libraries
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install hdf5
+          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
+      # install additional Macos dependencies
+      - name: install HDF5 libraries
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install hdf5
+          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

[CI on `macos-latest` (now a Silicon runner)](https://github.com/brainglobe/brainglobe-workflows/actions/runs/8848041813/job/24297125057#step:3:219) fails with `error: subprocess-exited-with-error` ~~when installing scikit-image,~~ when installing `pytables` ([presumably](https://stackoverflow.com/questions/73029883/could-not-find-hdf5-installation-for-pytables-on-m1-mac)) [because HDF5 libraries are missing.
](https://github.com/brainglobe/brainglobe-workflows/actions/runs/8848041813/job/24297125057#step:3:327)

**What does this PR do?**
* For the M1 CI, `brew install`s HDF5 libraries and adds them to the path.
* Ensures tests are run on Silicon and non-Silicon macs.

## References

Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

## How has this PR been tested?

This PR fixes the tests.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No
## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
