### PR TITLE
Cache for cellfinder workflow tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,6 +56,12 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install hdf5
+      # Cache cellfinder workflow data
+      - name: Cache data for cellfinder workflow tests
+        uses: actions/cache@v3
+        with:
+          path: ~/.brainglobe-tests
+          key: cellfinder-test-data
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We are trying to speed up tests in CI. This PR adds a cache for the cellfinder workflow tests that run in CI.

**What does this PR do?**
Adds a cache step to the test job that runs in CI.

## References

#65 

## How has this PR been tested?

Checks for this PR should pass.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ n/a] The code has been tested locally
- [ n/a] Tests have been added to cover all new functionality (unit & integration)
- [ n/a] The documentation has been updated to reflect any changes
- [ x] The code has been formatted with [pre-commit](https://pre-commit.com/)
