### PR TITLE
Remove calls to TensorFlow related cellfinder functions

### DIFF
--- a/brainglobe_workflows/brainmapper/main.py
+++ b/brainglobe_workflows/brainmapper/main.py
@@ -3,9 +3,6 @@ main
 ===============
 
 Runs each part of the brainmapper pipeline in turn.
-
-N.B imports are within functions to prevent tensorflow being imported before
-it's warnings are silenced
 """
 
 import logging
@@ -20,7 +17,6 @@ from brainglobe_utils.general.system import ensure_directory_exists
 from brainglobe_utils.image.heatmap import heatmap_from_points
 from brainglobe_utils.IO.cells import get_cells, save_cells
 from brainglobe_utils.IO.image.load import read_z_stack
-from cellfinder.core.main import suppress_tf_logging, tf_suppress_log_messages
 
 BRAINREG_PRE_PROCESSING_ARGS = None
 
@@ -44,7 +40,6 @@ def cells_exist(points_file):
 
 
 def main():
-    suppress_tf_logging(tf_suppress_log_messages)
     from brainreg.core.main import main as register
 
     from brainglobe_workflows.brainmapper import prep


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Cellfinder is now using PyTorch so functions related to suppressing TensorFlow error messages no longer exist.

**What does this PR do?**
Removes any comments and function calls relating to suppressing TensorFlow error messages.

## References
Waiting on https://github.com/brainglobe/cellfinder/pull/418 to be merged

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
