### PR TITLE
pin to pytorch-version of cellfinder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "brainglobe>=1.0.0",
     "brainreg>=1.0.0",
-    "cellfinder>=1.1.0",
+    "cellfinder>=1.3.0",
     "configobj",
     "fancylog>=0.0.7",
     "imio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 # Below the dependencies for brainmapper (the cellfinder CLI tool) only
 # (i.e., only what users will need for brainmapper)
 dependencies = [
-    "brainglobe>=1.0.0",
+    "brainglobe>=1.2.0",
     "brainreg>=1.0.0",
     "cellfinder>=1.3.0",
     "configobj",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Latest release of `brainglobe-workflows` is incompatible with latest `cellfinder`, because it tries to import `tensorflow`-related functionality. This is fixed in the development code by https://github.com/brainglobe/brainglobe-workflows/pull/112 but not released yet.

**What does this PR do?**
Makes sure the next release pins to a cellfinder version >= 1.3.0, so the API between the two packages in in-sync and up-to-date.

## References


\

## How has this PR been tested?

Not sure how to test this 😬 I have convinced myself I have thought this through.

## Is this a breaking change?

No. It's an adaptation to the latest cellfinder release.

## Does this PR require an update to the documentation?

No

## Checklist:

- [ \ ] The code has been tested locally
- [ \ ] Tests have been added to cover all new functionality (unit & integration)
- [ \ ] The documentation has been updated to reflect any changes
- [ \ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
