### PR TITLE
Avoid caching `pip` dependencies

### DIFF
--- a/benchmarks/asv.latest-github.conf.json
+++ b/benchmarks/asv.latest-github.conf.json
@@ -31,7 +31,7 @@
     // See asv.conf.json documentation.
     // overwrite dependencies from PyPi with latest `main` version from GitHub
     "install_command": [
-        "in-dir={env_dir} python -mpip install --force-reinstall '{wheel_file}'",
+        "in-dir={env_dir} python -mpip install --force-reinstall --no-cache-dir '{wheel_file}'",
         "in-dir={env_dir} python -mpip install -r {conf_dir}/latest-github-requirements.txt",
         "in-dir={env_dir} python -mpip list" // print dependencies' versions if asv ran with -v
     ],

--- a/benchmarks/asv.pip.conf.json
+++ b/benchmarks/asv.pip.conf.json
@@ -30,7 +30,7 @@
     // Customizable commands for installing and uninstalling the project.
     // See asv.conf.json documentation.
     "install_command": [
-        "in-dir={env_dir} python -mpip install --force-reinstall '{wheel_file}'",
+        "in-dir={env_dir} python -mpip install --force-reinstall --no-cache-dir '{wheel_file}'",
         "in-dir={env_dir} python -mpip list" // print dependencies' versions if asv ran with -v
     ],
     "uninstall_command": [


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

If we run the benchmarks using the current configurations on a local machine, we risk `pip` using its cache. This stops the benchmarks from being useful smoke tests for newer versions of dependencies breaking our code, which is a [key purpose of this repo](https://github.com/brainglobe/brainglobe-workflows/issues/57).

**What does this PR do?**
Stops `pip` from using cached dependencies when installing the package into the `asv` conda env.

## References

\

## How has this PR been tested?

Only understanding how pip works better. Suggestions for how to best test this welcome :thinking: 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

yes, but we should tackle that as a whole once we are happy with the workflows and our internal testing setup.

## Checklist:

- [ \ ] The code has been tested locally
- [ \ ] Tests have been added to cover all new functionality (unit & integration)
- [ \ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
