### PR TITLE
Replace `imio` with `brainglobe-utils`

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,10 +38,8 @@ jobs:
         # Run tests on ubuntu across all supported versions
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
-        # Include a Windows test and old/new Mac runs
+        # Include a Windows test and new Mac runs
         include:
-          - os: macos-13
-            python-version: "3.12"
           - os: macos-latest
             python-version: "3.12"
           - os: windows-latest

--- a/tests/brainmapper/test_integration/test_registration.py
+++ b/tests/brainmapper/test_integration/test_registration.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 import pandas as pd
 import pytest
-from imio.load import load_any
+from brainglobe_utils.IO.image import load_any
 
 from brainglobe_workflows.brainmapper.main import (
     main as cellfinder_run,


### PR DESCRIPTION
`imio` was still being used in the `brainmapper` tests. Replaced this with the appropriate `brainglobe-utils` function.