### PR TITLE
Use pypa/gh-action-pypi-publish stable release v1

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -149,7 +149,7 @@ jobs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.12.3
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TWINE_API_KEY }}


### PR DESCRIPTION
See merged PR at [brainglobe-atlasapi](https://github.com/brainglobe/brainglobe-atlasapi/pull/456) for more details