### PR TITLE
Pin brainglobe-utils version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 # (i.e., only what users will need for brainmapper)
 dependencies = [
     "brainglobe>=1.3.0",
+    "brainglobe-utils>=0.7.0",
     "configobj",
     "fancylog>=0.4.2",
     "multiprocessing-logging>=0.3.4",


### PR DESCRIPTION
Pin the version of brainglobe-utils to ensure that https://github.com/brainglobe/brainglobe-workflows/issues/137 is fixed when installing from pypi