### PR TITLE
Runs scheduled tests against napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -81,6 +81,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+      # Run tests on napari main if this is a scheduled run
+      - name: Run tests on napari main
+        if: github.event_name == 'schedule'
+        uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          tox-args: '-e napari-dev'
+
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
         uses: ravsamhq/notify-slack-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{311,312,313}-{coredev}
+envlist = py{311,312,313}-{coredev}, napari-dev
 isolated_build = True
 
 [gh-actions]
@@ -134,8 +134,10 @@ omit = benchmarks/*
 [testenv]
 extras =
     dev
+    napari
 deps =
     coredev: git+https://github.com/brainglobe/cellfinder.git
+    napari-dev: git+https://github.com/napari/napari
 commands =
     pytest {toxinidir} -v --color=yes --cov=./ --cov-report=xml
 description =


### PR DESCRIPTION
Adds an extra run of the neuroinformatics/actions/test with napari installed from main. This action will only run during the weekly cron job.