### PR TITLE
Remove napari dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,6 @@ dev = [
     "asv",
 ]
 
-
-napari = ["napari[pyqt5]", "brainglobe-napari-io", "cellfinder[napari]>=1.0.0"]
-
 [project.urls]
 "Bug Tracker" = "https://github.com/brainglobe/brainglobe-workflows/issues"
 "Documentation" = "https://brainglobe.info/documentation/brainglobe-workflows"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ omit = benchmarks/*
 [testenv]
 extras =
     dev
-    napari
 deps =
     coredev: git+https://github.com/brainglobe/cellfinder.git
     napari-dev: git+https://github.com/napari/napari


### PR DESCRIPTION
## Description

**What does this PR do?**

Removes all direct `napari` dependencies, as we don't import in this codebase. We indirectly depend on `napari[all]` via the metapackage.

## References

Closes #174 